### PR TITLE
feat(pallet-ranked-collective): added types

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -925,6 +925,8 @@ impl pallet_referenda::Config<pallet_referenda::Instance2> for Runtime {
 impl pallet_ranked_collective::Config for Runtime {
 	type WeightInfo = pallet_ranked_collective::weights::SubstrateWeight<Self>;
 	type RuntimeEvent = RuntimeEvent;
+	type AddOrigin = EnsureRoot<AccountId>;
+	type RemoveOrigin = EnsureRootWithSuccess<AccountId, ConstU16<65535>>;
 	type PromoteOrigin = EnsureRootWithSuccess<AccountId, ConstU16<65535>>;
 	type DemoteOrigin = EnsureRootWithSuccess<AccountId, ConstU16<65535>>;
 	type Polls = RankedPolls;

--- a/frame/ranked-collective/src/benchmarking.rs
+++ b/frame/ranked-collective/src/benchmarking.rs
@@ -37,8 +37,8 @@ fn make_member<T: Config<I>, I: 'static>(rank: Rank) -> T::AccountId {
 	let who = account::<T::AccountId>("member", MemberCount::<T, I>::get(0), SEED);
 	let who_lookup = T::Lookup::unlookup(who.clone());
 	assert_ok!(Pallet::<T, I>::add_member(
-		T::PromoteOrigin::try_successful_origin()
-			.expect("PromoteOrigin has no successful origin required for the benchmark"),
+		T::AddOrigin::try_successful_origin()
+			.expect("AddOrigin has no successful origin required for the benchmark"),
 		who_lookup.clone(),
 	));
 	for _ in 0..rank {
@@ -56,7 +56,7 @@ benchmarks_instance_pallet! {
 		let who = account::<T::AccountId>("member", 0, SEED);
 		let who_lookup = T::Lookup::unlookup(who.clone());
 		let origin =
-			T::PromoteOrigin::try_successful_origin().map_err(|_| BenchmarkError::Weightless)?;
+			T::AddOrigin::try_successful_origin().map_err(|_| BenchmarkError::Weightless)?;
 		let call = Call::<T, I>::add_member { who: who_lookup };
 	}: { call.dispatch_bypass_filter(origin)? }
 	verify {
@@ -73,7 +73,7 @@ benchmarks_instance_pallet! {
 		let last = make_member::<T, I>(rank);
 		let last_index = (0..=rank).map(|r| IdToIndex::<T, I>::get(r, &last).unwrap()).collect::<Vec<_>>();
 		let origin =
-			T::DemoteOrigin::try_successful_origin().map_err(|_| BenchmarkError::Weightless)?;
+			T::RemoveOrigin::try_successful_origin().map_err(|_| BenchmarkError::Weightless)?;
 		let call = Call::<T, I>::remove_member { who: who_lookup, min_rank: rank };
 	}: { call.dispatch_bypass_filter(origin)? }
 	verify {
@@ -124,8 +124,8 @@ benchmarks_instance_pallet! {
 		let caller: T::AccountId = whitelisted_caller();
 		let caller_lookup = T::Lookup::unlookup(caller.clone());
 		assert_ok!(Pallet::<T, I>::add_member(
-			T::PromoteOrigin::try_successful_origin()
-				.expect("PromoteOrigin has no successful origin required for the benchmark"),
+			T::AddOrigin::try_successful_origin()
+				.expect("AddOrigin has no successful origin required for the benchmark"),
 			caller_lookup.clone(),
 		));
 		// Create a poll

--- a/frame/ranked-collective/src/tests.rs
+++ b/frame/ranked-collective/src/tests.rs
@@ -28,7 +28,7 @@ use frame_support::{
 use sp_core::{Get, H256};
 use sp_runtime::{
 	testing::Header,
-	traits::{BlakeTwo256, IdentityLookup, ReduceBy},
+	traits::{BlakeTwo256, IdentityLookup, ReduceBy, ReplaceWithDefaultFor},
 	BuildStorage,
 };
 
@@ -182,6 +182,8 @@ parameter_types! {
 impl Config for Test {
 	type WeightInfo = ();
 	type RuntimeEvent = RuntimeEvent;
+	type AddOrigin = MapSuccess<Self::PromoteOrigin, ReplaceWithDefaultFor<()>>;
+	type RemoveOrigin = Self::DemoteOrigin;
 	type PromoteOrigin = EitherOf<
 		// Root can promote arbitrarily.
 		frame_system::EnsureRootWithSuccess<Self::AccountId, ConstU16<65535>>,

--- a/primitives/runtime/src/traits.rs
+++ b/primitives/runtime/src/traits.rs
@@ -540,6 +540,9 @@ morph_types! {
 	/// Morpher to disregard the source value and replace with another.
 	pub type Replace<V: TypedGet> = |_| -> V::Type { V::get() };
 
+	/// Morpher to disregard the source value and replace with default for T.
+	pub type ReplaceWithDefaultFor<T: Default> = |_| -> T { T::default() };
+
 	/// Mutator which reduces a scalar by a particular amount.
 	pub type ReduceBy<N: TypedGet> = |r: N::Type| -> N::Type {
 		r.checked_sub(&N::get()).unwrap_or(Zero::zero())


### PR DESCRIPTION
This PR added associated types(`AddOrigin` & `RemoveOrigin`) to `Config`.It allows you to decouple types and areas of responsibility, since at the moment the same types are responsible for adding and promoting(removing and demoting).
```
/// The origin required to add a member.
type AddOrigin: EnsureOrigin<Self::RuntimeOrigin, Success = ()>;

/// The origin required to remove a member. The success value indicates the
/// maximum rank *from which* the removal may be.
type RemoveOrigin: EnsureOrigin<Self::RuntimeOrigin, Success = Rank>;
```

To achieve the backward compatibility, the users of the pallet can use the old type via the new morph:
```
type AddOrigin = MapSuccess<PromoteOriginType, ReplaceWithDefaultFor<()>>;
```

Polkadot companion: https://github.com/praetorp/polkadot/pull/2